### PR TITLE
Fix destroy on a branch not working

### DIFF
--- a/.github/workflows/development-cluster-deploy-workspaces.yml
+++ b/.github/workflows/development-cluster-deploy-workspaces.yml
@@ -22,7 +22,7 @@ on:
         default: "cp-date-time"
         type: string
       branch_name:
-        description: "Name of the branch to deploy from (defaults to main)"
+        description: "Name of the branch in MP environments repo to deploy from (defaults to main)"
         required: false
         default: "main"
         type: string
@@ -175,6 +175,7 @@ jobs:
           uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
           with:
             repository: 'ministryofjustice/modernisation-platform-environments'
+            ref: ${{ inputs.branch_name }}
         
         - name: Prepare Files
           run: |

--- a/.github/workflows/development-cluster-deploy.yml
+++ b/.github/workflows/development-cluster-deploy.yml
@@ -163,6 +163,7 @@ jobs:
           uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
           with:
             repository: 'ministryofjustice/modernisation-platform-environments'
+            ref: ${{ inputs.branch_name }}
         
         - name: Prepare Files
           run: |


### PR DESCRIPTION
Technically this is not needed for everyday cluster work, but if you make script alterations on a branch and the destroy needs those script alterations then without this it will fail.