### PR TITLE
fix: remove created_by label

### DIFF
--- a/.github/workflows/development-cluster-deploy.yml
+++ b/.github/workflows/development-cluster-deploy.yml
@@ -121,13 +121,13 @@ jobs:
         - name: Cluster Terraform Plan
           run: |
             set -o pipefail
-            terraform plan -var="created_by=${{ github.actor }}" | ../../../../scripts/redact-output.sh
+            terraform plan | ../../../../scripts/redact-output.sh
           working-directory: terraform/environments/cloud-platform-non-live/cluster
 
         - name: Cluster Terraform Apply
           run: |
             set -o pipefail
-            terraform apply -var="created_by=${{ github.actor }}" -auto-approve | ../../../../scripts/redact-output.sh
+            terraform apply -auto-approve | ../../../../scripts/redact-output.sh
           working-directory: terraform/environments/cloud-platform-non-live/cluster
 
         - name: Cluster-core Terraform fmt


### PR DESCRIPTION
## Purpose

- This removes the created_by label in terraform, it causes a problem when trying to apply terraform in the cluster layer if your not the user that created the cluster.