### PR TITLE
ci: add cluster name to github step summary

### DIFF
--- a/.github/workflows/development-cluster-deploy.yml
+++ b/.github/workflows/development-cluster-deploy.yml
@@ -48,6 +48,16 @@ jobs:
           echo "cluster_name=$CLUSTER_NAME" >> $GITHUB_OUTPUT
           echo "Cluster Name: $CLUSTER_NAME"
 
+      - name: Show Cluster Name
+        continue-on-error: true
+        run: |
+          {
+            echo "## Development Cluster"
+            echo ""
+            echo "- Action: \`${{ inputs.cluster_action }}\`"
+            echo "- Cluster name: \`${{ steps.set-cluster-name.outputs.cluster_name }}\`"
+          } >> $GITHUB_STEP_SUMMARY
+
   deploy-development-cluster:
     name: Deploy Development Cluster
     if: inputs.cluster_action == 'deploy'
@@ -193,6 +203,16 @@ jobs:
     if: inputs.cluster_action == 'destroy' && inputs.cluster_name != 'cp-date-time'
     runs-on: ubuntu-latest
     steps:
+        - name: Show Cluster Name
+          continue-on-error: true
+          run: |
+            {
+              echo "## Development Cluster"
+              echo ""
+              echo "- Action: \`${{ inputs.cluster_action }}\`"
+              echo "- Cluster name: \`${{ inputs.cluster_name }}\`"
+            } >> $GITHUB_STEP_SUMMARY
+
         - name: Checkout Repository
           uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
           with:


### PR DESCRIPTION
Add a tiny summary for the test cluster workflow so we can grab cluster name easily

<img width="1036" height="783" alt="image" src="https://github.com/user-attachments/assets/ab964a32-f7e1-4a2a-a79e-25d0d83d30d9" />
