### PR TITLE
Add integration tests to deployment pipeline

### DIFF
--- a/.github/workflows/development-cluster-deploy.yml
+++ b/.github/workflows/development-cluster-deploy.yml
@@ -179,7 +179,7 @@ jobs:
     uses: ./.github/workflows/integration-tests.yml
     secrets: inherit
     with:
-      cluster_name: ${{ needs.set-cluster-name.outputs.cluster_name }}
+      cluster_name: ${{ needs.set-cluster-name.outputs.cluster_name }} # Do not pass a branch and tests will run against container-platform-integration-tests/main. Could pass through in future
           
   destroy-development-cluster:
     name: Destroy Development Cluster

--- a/.github/workflows/development-cluster-deploy.yml
+++ b/.github/workflows/development-cluster-deploy.yml
@@ -25,6 +25,7 @@ on:
 permissions:
   id-token: write  # This is required for requesting the JWT
   contents: read  # This is required for actions/checkout
+  checks: write # Required for integration-tests.yml: publishing test reports
 
 run-name: "${{ inputs.cluster_action }} development cluster by @${{ github.actor }}"
 
@@ -169,6 +170,17 @@ jobs:
             terraform apply -auto-approve | ../../../../scripts/redact-output.sh
           working-directory: terraform/environments/cloud-platform/cluster-components
 
+  run-integration-tests:
+    name: Run Integration Tests After Deploy
+    if: inputs.cluster_action == 'deploy'
+    needs:
+      - set-cluster-name
+      - deploy-development-cluster
+    uses: ./.github/workflows/integration-tests.yml
+    secrets: inherit
+    with:
+      cluster_name: ${{ needs.set-cluster-name.outputs.cluster_name }}
+          
   destroy-development-cluster:
     name: Destroy Development Cluster
     if: inputs.cluster_action == 'destroy' && inputs.cluster_name != 'cp-date-time'

--- a/.github/workflows/development-cluster-deploy.yml
+++ b/.github/workflows/development-cluster-deploy.yml
@@ -179,7 +179,7 @@ jobs:
     uses: ./.github/workflows/integration-tests.yml
     secrets: inherit
     with:
-      cluster_name: ${{ needs.set-cluster-name.outputs.cluster_name }} # Do not pass a branch and tests will run against container-platform-integration-tests/main. Could pass through in future
+      cluster_name: ${{ needs.set-cluster-name.outputs.cluster_name }} # Do not pass a branch and it will default to container-platform-integration-tests/main. Could pass through in future
           
   destroy-development-cluster:
     name: Destroy Development Cluster

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -13,6 +13,22 @@ on:
           default: "main"
           type: string
 
+  workflow_call:
+    inputs:
+      cluster_name:
+        description: "Name of the target cluster for integration test run"
+        required: true
+        type: string
+      branch_name:
+        description: "Name of integration tests repository branch to use"
+        required: false
+        default: "main"
+        type: string
+
+env:
+  CLUSTER_NAME: ${{ inputs.cluster_name || github.event.inputs.cluster_name }}
+  BRANCH_NAME: ${{ inputs.branch_name || github.event.inputs.branch_name }}
+
 permissions:
   id-token: write  # This is required for requesting the JWT
   contents: read  # This is required for actions/checkout
@@ -42,6 +58,7 @@ jobs:
            with:
              repository: 'ministryofjustice/container-platform-integration-tests'
              ref: ${{ inputs.branch_name }}
+             ref: ${{ env.BRANCH_NAME }}
 
          - name: Configure AWS Credentials
            uses: aws-actions/configure-aws-credentials@00943011d9042930efac3dcd3a170e4273319bc8 # v5.1.0
@@ -68,9 +85,14 @@ jobs:
          - name: Check kube config
            run: |
             kubectl config current-context || true
+
          - name: Run integration tests
            run: |
-             cd ./test;  ginkgo -r -v --show-node-events --output-interceptor-mode=none --junit-report=report.xml -- -cluster=${{ needs.set-cluster-name.outputs.cluster_name }}
+             echo "Cluster from shell: $CLUSTER_NAME"
+             env | grep CLUSTER_NAME || echo "CLUSTER_NAME not found in env"
+             cd ./test
+             pwd
+             ginkgo -r -v --show-node-events --output-interceptor-mode=none --junit-report=report.xml -- -cluster=${{ needs.set-cluster-name.outputs.cluster_name }}
 
          - name: Upload test report
            uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -87,8 +87,6 @@ jobs:
 
          - name: Run integration tests
            run: |
-             echo "Cluster from shell: $CLUSTER_NAME"
-             env | grep CLUSTER_NAME || echo "CLUSTER_NAME not found in env"
              cd ./test
              pwd
              ginkgo -r -v --show-node-events --output-interceptor-mode=none --junit-report=report.xml -- -cluster=${{ needs.set-cluster-name.outputs.cluster_name }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -57,7 +57,6 @@ jobs:
            uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
            with:
              repository: 'ministryofjustice/container-platform-integration-tests'
-             ref: ${{ inputs.branch_name }}
              ref: ${{ env.BRANCH_NAME }}
 
          - name: Configure AWS Credentials

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,8 +7,8 @@ on:
         description: "Name of the target cluster for integration test run"
         required: true
         type: string
-      branch_name:
-          description: "Name of integration tests repository branch to use"
+      tests_branch_name:
+          description: "Name of container-platform-integration-tests repository branch to use"
           required: false
           default: "main"
           type: string
@@ -19,15 +19,15 @@ on:
         description: "Name of the target cluster for integration test run"
         required: true
         type: string
-      branch_name:
-        description: "Name of integration tests repository branch to use"
+      tests_branch_name:
+        description: "Name of container-platform-integration-tests repository branch to use"
         required: false
         default: "main"
         type: string
 
 env:
   CLUSTER_NAME: ${{ inputs.cluster_name || github.event.inputs.cluster_name }}
-  BRANCH_NAME: ${{ inputs.branch_name || github.event.inputs.branch_name }}
+  INTEGRATION_TESTS_BRANCH_NAME: ${{ inputs.tests_branch_name || github.event.inputs.tests_branch_name }}
 
 permissions:
   id-token: write  # This is required for requesting the JWT
@@ -57,7 +57,7 @@ jobs:
            uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
            with:
              repository: 'ministryofjustice/container-platform-integration-tests'
-             ref: ${{ env.BRANCH_NAME }}
+             ref: ${{ env.INTEGRATION_TESTS_BRANCH_NAME }}
 
          - name: Configure AWS Credentials
            uses: aws-actions/configure-aws-credentials@00943011d9042930efac3dcd3a170e4273319bc8 # v5.1.0


### PR DESCRIPTION
Add integration tests into the CP3 cluster build flow

- Tests will run after every cluster deploy
- Deployment marked as failed if the tests fail, but the cluster will still be there
- No changes to the destroy flow, so you should still be able to destroy off cloud-platform-github-workflows main after this is merged
- You can still run integration tests as a standalone