### PR TITLE
feat(workflow): Add ArgoCD enablement input to dev cluster deploy

### DIFF
--- a/.github/workflows/development-cluster-deploy.yml
+++ b/.github/workflows/development-cluster-deploy.yml
@@ -26,6 +26,11 @@ on:
         required: false
         default: "main"
         type: string
+      enable_argocd:
+        description: "Enable ArgoCD EKS Capability on this cluster (hub cluster role)"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   id-token: write  # This is required for requesting the JWT
@@ -64,6 +69,7 @@ jobs:
             echo "- Cluster name: \`${{ steps.set-cluster-name.outputs.cluster_name }}\`"
             echo "- modernisation-platform-environments branch name: \`${{ inputs.branch_name }}\`"
             echo "- container-platform-integration-tests branch name: \`${{ inputs.tests_branch_name }}\`"
+            echo "- ArgoCD enabled: \`${{ inputs.enable_argocd }}\`"
           } >> $GITHUB_STEP_SUMMARY
 
   deploy-development-cluster:
@@ -110,13 +116,21 @@ jobs:
         - name: Cluster Terraform Plan
           run: |
             set -o pipefail
-            terraform plan -var=created_by=${{ github.actor }} | ../../../../scripts/redact-output.sh
+            terraform plan \
+              -var=created_by=${{ github.actor }} \
+              -var=enable_argocd=${{ inputs.enable_argocd }} \
+              -var=argocd_idc_instance_arn=${{ secrets.ARGOCD_IDC_INSTANCE_ARN }} \
+              | ../../../../scripts/redact-output.sh
           working-directory: terraform/environments/cloud-platform/cluster
 
         - name: Cluster Terraform Apply
           run: |
             set -o pipefail
-            terraform apply -auto-approve -var=created_by=${{ github.actor }} | ../../../../scripts/redact-output.sh
+            terraform apply -auto-approve \
+              -var=created_by=${{ github.actor }} \
+              -var=enable_argocd=${{ inputs.enable_argocd }} \
+              -var=argocd_idc_instance_arn=${{ secrets.ARGOCD_IDC_INSTANCE_ARN }} \
+              | ../../../../scripts/redact-output.sh
           working-directory: terraform/environments/cloud-platform/cluster
 
         - name: Cluster-core Terraform fmt


### PR DESCRIPTION
## Summary

Adds an `enable_argocd` boolean input to the `development-cluster-deploy` workflow. When checked, passes `TF_VAR_enable_argocd=true` and the `ARGOCD_IDC_INSTANCE_ARN` secret to the cluster Terraform plan/apply steps.

## Changes

- New workflow input: `enable_argocd` (boolean, default false)
- Cluster Terraform plan/apply steps pass `-var=enable_argocd` and `-var=argocd_idc_instance_arn` from secret
- Job summary updated to show ArgoCD status
- Destroy step unchanged (uses variable defaults)

## Usage

1. Add `ARGOCD_IDC_INSTANCE_ARN` as a repo secret
2. Run the workflow with "Enable ArgoCD" ticked to deploy a hub cluster
3. Leave unchecked for regular spoke/dev clusters (no behaviour change)

## Dependencies

- Companion infrastructure PR [#17650](https://github.com/ministryofjustice/modernisation-platform-environments/pull/17650) in `modernisation-platform-environments` (ArgoCD module)

## Issue

https://github.com/ministryofjustice/cloud-platform/issues/8269
